### PR TITLE
Change top articles result from today to yesterday

### DIFF
--- a/wmf/analytics/api/pageviews.py
+++ b/wmf/analytics/api/pageviews.py
@@ -225,10 +225,10 @@ class PageviewsClient:
                 ...
             ]
         """
-        today = date.today()
-        year = str(year or today.year)
-        month = str(month or today.month).rjust(2, '0')
-        day = str(day or today.day).rjust(2, '0')
+        yesterday = date.today() - timedelta(days=1)
+        year = str(year or yesterday.year)
+        month = str(month or yesterday.month).rjust(2, '0')
+        day = str(day or yesterday.day).rjust(2, '0')
 
         url = '/'.join([endpoints['top'], project, access, year, month, day])
         result = requests.get(url).json()


### PR DESCRIPTION
The default day to fetch top results was "today", but the statistics seemed not to be available. "Yesterday" results are apparently available. Issue  #5